### PR TITLE
Fix "ASCII to Decimal" command

### DIFF
--- a/src/encode-decode-tools.ts
+++ b/src/encode-decode-tools.ts
@@ -114,7 +114,7 @@ class EncodeDecodeTools extends VSCodeTextTools {
         for (const letter of text) {
             let decimal = Number(letter.charCodeAt(0).toString(10));
 
-            if (fn) {
+            if (fn && typeof fn === 'function') {
                 decimal = fn(decimal);
             }
 


### PR DESCRIPTION
Calling this function via the command palette's "ASCII to Decimal" option always results in an Error being thrown. This fix adds a safeguard `typeof` check before calling an optional argument whose type may not be function.

I observed this and did some debugging against the minified source. I don't see any reason there should be a second argument in the first place, but if it's expected this fixes the issue. It looks like the call comes from

```ts
// tools.ts:47
const response = fn.apply(this, [text, selection]);
```

and the results I saw were consistent with an Array being passed instead of a function.